### PR TITLE
Update URLKey Type Annotations

### DIFF
--- a/shorturl/database/objects.py
+++ b/shorturl/database/objects.py
@@ -2,6 +2,8 @@ import string, random
 from dataclasses import dataclass, field
 from pydantic import HttpUrl, Field
 
+KEYLEN = 8
+
 @dataclass
 class URL:
     url: HttpUrl
@@ -9,4 +11,4 @@ class URL:
 
 @dataclass
 class URLKey(URL):
-    key: str = field(default_factory=lambda: ''.join(random.choices(string.ascii_letters+string.digits, k=8)))
+    key: str = Field(default_factory=lambda: ''.join(random.choices(string.ascii_letters + string.digits, k=KEYLEN)), min_length=KEYLEN, max_length=KEYLEN)

--- a/shorturl/database/objects.py
+++ b/shorturl/database/objects.py
@@ -11,4 +11,4 @@ class URL:
 
 @dataclass
 class URLKey(URL):
-    key: str = Field(default_factory=lambda: ''.join(random.choices(string.ascii_letters + string.digits, k=KEYLEN)), min_length=KEYLEN, max_length=KEYLEN)
+    key: str = field(default_factory=lambda: ''.join(random.choices(string.ascii_letters+string.digits, k=KEYLEN)), metadata={"min_length": KEYLEN, "max_length": KEYLEN})


### PR DESCRIPTION
Replace dataclass.field with pydantic.Field to allow for more specfic Type Annotations on the URLKey object. This allows the string to have an absolute length based on the KEYLEN environment variable defined in issue https://github.com/oliv10/ShortURL/issues/3.